### PR TITLE
Add issue template for glyph sequence reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/glyph-sequence-report.yml
+++ b/.github/ISSUE_TEMPLATE/glyph-sequence-report.yml
@@ -1,0 +1,73 @@
+name: Glyph sequence report
+description: Report a missing, incorrect, or ambiguous glyph sequence entry in glyph.csv.
+title: "[Glyph sequence] "
+labels:
+  - glyph-sequence
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve `glyph.csv`.
+
+        Please include enough detail to verify and reproduce the issue.
+
+        **Important:** Attach a screenshot that clearly shows the sequence source.
+  - type: dropdown
+    id: report_type
+    attributes:
+      label: Report type
+      description: What kind of sequence issue are you reporting?
+      options:
+        - Missing sequence
+        - Incorrect sequence
+        - Duplicate/ambiguous sequence
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: glyph_name
+    attributes:
+      label: Glyph name
+      description: The glyph name as used in `glyph_line.csv`.
+      placeholder: "e.g. Abaddon"
+    validations:
+      required: true
+  - type: input
+    id: current_sequence
+    attributes:
+      label: Current sequence in glyph.csv (if any)
+      description: Leave blank if this is a missing sequence report.
+      placeholder: "e.g. 142353"
+    validations:
+      required: false
+  - type: input
+    id: proposed_sequence
+    attributes:
+      label: Proposed/correct sequence
+      description: The sequence you believe should be used.
+      placeholder: "e.g. 14235"
+    validations:
+      required: true
+  - type: textarea
+    id: source
+    attributes:
+      label: Source and evidence
+      description: Share links, references, or explanation supporting your report.
+      placeholder: "Provide source links and a short explanation."
+    validations:
+      required: true
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: Screenshot
+      description: Paste or attach a screenshot that confirms the sequence.
+      placeholder: "Drag and drop image(s) here."
+    validations:
+      required: true
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Any extra notes that may help maintainers validate this report.
+    validations:
+      required: false


### PR DESCRIPTION
### Motivation
- Add a GitHub issue form to standardize reporting of missing, incorrect, or ambiguous glyph sequences and require a screenshot to ensure reproducible reports.

### Description
- Create `.github/ISSUE_TEMPLATE/glyph-sequence-report.yml` which pre-fills the issue title, applies a `glyph-sequence` label, and defines structured fields for report type, glyph name, current/proposed sequence, source/evidence, required screenshot, and optional additional context.

### Testing
- Verified the generated YAML content and syntax by printing the file with `sed -n '1,220p'` and `nl -ba`, and confirmed the file was staged and committed by observing `git status --short` and a successful commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eda67cd688331ba536717e02974ca)